### PR TITLE
Optional addition to the Orchestrator Service File

### DIFF
--- a/docs/setting-up-a-validator.md
+++ b/docs/setting-up-a-validator.md
@@ -115,8 +115,7 @@ For the orchestrator most people will not need to modify anything. But if you wi
 ```text
 ExecStart=/usr/bin/gbt orchestrator \
 --ethereum-rpc <ETHEREUM_RPC> \
---fees <fees> \
-start
+--fees <fees>
 ```
 
 Now that we have modified these services it's time to set them to run on startup


### PR DESCRIPTION
"start" is not a sub command within the gbt orchestrator command. Currently the optional modifications provided in the service file break the service.