### PR TITLE
Update validator docs for v1.11.1

### DIFF
--- a/docs/setting-up-a-validator.md
+++ b/docs/setting-up-a-validator.md
@@ -19,12 +19,12 @@ cd gravity-bin
 
 # the gravity chain binary itself
 
-wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.8.1/gravity-linux-amd64
+wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.11.1/gravity-linux-amd64
 mv gravity-linux-amd64 gravity
 
 # Tools for the gravity bridge from the gravity repo
 
-wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.8.1/gbt
+wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.11.1/gbt
 chmod +x *
 sudo mv * /usr/bin/
 
@@ -32,7 +32,7 @@ sudo mv * /usr/bin/
 
 At specific points you may be told to 'update your orchestrator' or 'update your gravity binary'. In order to do that you can simply repeat the above instructions and then restart the affected software.
 
-to check what version of the tools you have run `gbt --version` the current latest version is `gbt 1.8.1`
+to check what version of the tools you have run `gbt --version` the current latest version is `gbt 1.11.1`
 
 ## Download and install geth
 

--- a/docs/upgrading-tools.md
+++ b/docs/upgrading-tools.md
@@ -11,7 +11,7 @@ cd gravity-bin
 
 # Tools for the gravity bridge from the gravity repo
 
-wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.7.0/gbt
+wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.11.1/gbt
 chmod +x *
 sudo mv * /usr/bin/
 
@@ -19,6 +19,6 @@ sudo mv * /usr/bin/
 
 At specific points you may be told to 'update your orchestrator'. In order to do that you can simply repeat the above instructions and then restart the affected software.
 
-to check what version of the tools you have run `gbt --version` the current latest version is `gbt 1.7.0`
+to check what version of the tools you have run `gbt --version` the current latest version is `gbt 1.11.1`
 
 gbt will start, print a few messages about resyncing and startup, and then be silent. If you see any messages with the `warn` or `error` log level read them and follow the provided instructions quickly. As a validator you may be slashed if your orchestrator fails to provide signatures for more than 10,000 blocks.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -72,12 +72,12 @@ cd gravity-bin
 
 # the gravity chain binary itself
 
-wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.8.1/gravity-linux-amd64
+wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.11.1/gravity-linux-amd64
 mv gravity-linux-amd64 gravity
 
 # Tools for the gravity bridge from the gravity repo
 
-wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.8.1/gbt
+wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/v1.11.1/gbt
 chmod +x *
 sudo mv * /usr/bin/
 ```

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -89,7 +89,7 @@ If you are validating on any of these platforms you will need to build your own 
 ```
 git clone https://github.com/Gravity-Bridge/Gravity-Bridge
 cd Gravity-Bridge/module
-git checkout v1.8.1
+git checkout v1.11.1
 make install
 cp $GOPATH/bin/gravity /usr/bin/gravity
 ```


### PR DESCRIPTION
Updating validator docs to reference the latest v1.11.1 which will hopefully prevent wild goose chases with errors for validators trying to reset or repair their installations.